### PR TITLE
Add 2015 and 2017 leap seconds

### DIFF
--- a/tai64n.go
+++ b/tai64n.go
@@ -20,6 +20,8 @@ import (
 var leapSeconds = []int64{
 	// subtract 2208988800 to convert from NTP datetime to unix seconds
 	// then add number of previous leap seconds to get TAI-since-unix-epoch
+	1483228836,
+	1435708835,
 	1341100834,
 	1230768033,
 	1136073632,


### PR DESCRIPTION
Sepcifically:
  - 3644697600	36	# 1 Jul 2015
  - 3692217600	37	# 1 Jan 2017

As listed here: https://www.ietf.org/timezones/data/leap-seconds.list

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

--- 

Not sure if this is still maintained, but in case others depend on this repository, they can cherry-pick this patch.